### PR TITLE
Added support for new model specs

### DIFF
--- a/experiments/E0/model003/input.json
+++ b/experiments/E0/model003/input.json
@@ -14,7 +14,9 @@
         "model": "MODEL003",
         "model_args": {
             "lambda_dir": 10.0,
-            "target_angle": 0.0
+            "target_angle": 0.0,
+            "cpm_force_mode": "reciprocal",
+            "cpm_update_direction": "source-to-target"
         }
     },
     "sim": {

--- a/experiments/E0/model003/input.json
+++ b/experiments/E0/model003/input.json
@@ -15,8 +15,8 @@
         "model_args": {
             "lambda_dir": 10.0,
             "target_angle": 0.0,
-            "cpm_force_mode": "reciprocal",
-            "cpm_update_direction": "source-to-target"
+            "cpm_force_mode": "extension",
+            "cpm_update_direction": "source-to-target-unnorm"
         }
     },
     "sim": {

--- a/experiments/E0/model005/input.json
+++ b/experiments/E0/model005/input.json
@@ -15,7 +15,9 @@
         "model_args": {
             "persist": 0.1,
             "mu": 20,
-            "dt": 50
+            "dt": 50,
+            "cpm_force_mode": "reciprocal",
+            "cpm_update_direction": "source-to-target"
         }
     },
     "sim": {

--- a/experiments/E0/model005/input.json
+++ b/experiments/E0/model005/input.json
@@ -16,8 +16,8 @@
             "persist": 0.1,
             "mu": 20,
             "dt": 50,
-            "cpm_force_mode": "reciprocal",
-            "cpm_update_direction": "source-to-target"
+            "cpm_force_mode": "extension",
+            "cpm_update_direction": "source-to-target-unnorm"
         }
     },
     "sim": {

--- a/experiments/E1/model003/input.json
+++ b/experiments/E1/model003/input.json
@@ -14,7 +14,9 @@
         "model": "MODEL003",
         "model_args": {
             "lambda_dir": 10.0,
-            "target_angle": 0.0
+            "target_angle": 0.0,
+            "cpm_force_mode": "reciprocal",
+            "cpm_update_direction": "source-to-target"
         }
     },
     "sim": {

--- a/experiments/E1/model003/input.json
+++ b/experiments/E1/model003/input.json
@@ -15,8 +15,8 @@
         "model_args": {
             "lambda_dir": 10.0,
             "target_angle": 0.0,
-            "cpm_force_mode": "reciprocal",
-            "cpm_update_direction": "source-to-target"
+            "cpm_force_mode": "extension",
+            "cpm_update_direction": "source-to-target-unnorm"
         }
     },
     "sim": {

--- a/experiments/E1/model005/input.json
+++ b/experiments/E1/model005/input.json
@@ -15,7 +15,9 @@
         "model_args": {
             "persist": 0.1,
             "mu": 20,
-            "dt": 50
+            "dt": 50,
+            "cpm_force_mode": "reciprocal",
+            "cpm_update_direction": "source-to-target"
         }
     },
     "sim": {

--- a/experiments/E1/model005/input.json
+++ b/experiments/E1/model005/input.json
@@ -16,8 +16,8 @@
             "persist": 0.1,
             "mu": 20,
             "dt": 50,
-            "cpm_force_mode": "reciprocal",
-            "cpm_update_direction": "source-to-target"
+            "cpm_force_mode": "extension",
+            "cpm_update_direction": "source-to-target-unnorm"
         }
     },
     "sim": {

--- a/implementations/compucell3d/model.py
+++ b/implementations/compucell3d/model.py
@@ -12,6 +12,13 @@ cell_type_name = 'Cell'
 HAS_SURFACE_NBS = 'neighbor_order' in pcs.SurfacePlugin.check_dict
 
 
+force_mapping = {
+    'extension': pcs.EXTERNALPOTENTIAL_FORCETYPEEXTENSION,
+    'retraction': pcs.EXTERNALPOTENTIAL_FORCETYPERETRACTION,
+    'reciprocal': pcs.EXTERNALPOTENTIAL_FORCETYPERECIPROCAL
+}
+
+
 def _impl_MODEL000(**kwargs):
     return []
 
@@ -22,15 +29,12 @@ def _impl_MODEL003(**kwargs):
     cpm_force_mode = kwargs['cpm_force_mode']
     cpm_update_direction = kwargs['cpm_update_direction']
 
-    if cpm_force_mode in ['extension', 'retraction']:
-        raise ValueError(f'CC3D does not support the specified force mode: {cpm_force_mode}')
-    if cpm_update_direction == 'source-to-target-norm':
-        raise ValueError(f'CC3D does not support the specified movement term: {cpm_update_direction}')
-
     return [
         pcs.ExternalPotentialPlugin(lambda_x=lambda_dir * cos(target_angle),
                                     lambda_y=lambda_dir * sin(target_angle),
-                                    com_based=cpm_update_direction == 'cell-mass-displacement')
+                                    com_based=cpm_update_direction == 'cell-mass-displacement',
+                                    force_type=force_mapping[cpm_force_mode],
+                                    normalized=cpm_update_direction == 'source-to-target-norm')
     ]
 
 
@@ -38,13 +42,10 @@ def _impl_MODEL005(**kwargs):
     cpm_force_mode = kwargs['cpm_force_mode']
     cpm_update_direction = kwargs['cpm_update_direction']
 
-    if cpm_force_mode in ['extension', 'retraction']:
-        raise ValueError(f'CC3D does not support the specified force mode: {cpm_force_mode}')
-    if cpm_update_direction == 'source-to-target-norm':
-        raise ValueError(f'CC3D does not support the specified movement term: {cpm_update_direction}')
-
     return [
-        pcs.ExternalPotentialPlugin(com_based=cpm_update_direction == 'cell-mass-displacement')
+        pcs.ExternalPotentialPlugin(com_based=cpm_update_direction == 'cell-mass-displacement',
+                                    force_type=force_mapping[cpm_force_mode],
+                                    normalized=cpm_update_direction == 'source-to-target-norm')
     ]
 
 

--- a/implementations/compucell3d/model.py
+++ b/implementations/compucell3d/model.py
@@ -19,15 +19,32 @@ def _impl_MODEL000(**kwargs):
 def _impl_MODEL003(**kwargs):
     lambda_dir = - float(kwargs['lambda_dir'])
     target_angle = float(kwargs['target_angle'])
+    cpm_force_mode = kwargs['cpm_force_mode']
+    cpm_update_direction = kwargs['cpm_update_direction']
+
+    if cpm_force_mode in ['extension', 'contraction']:
+        raise ValueError(f'CC3D does not support the specified force mode: {cpm_force_mode}')
+    if cpm_update_direction == 'source-to-target-norm':
+        raise ValueError(f'CC3D does not support the specified movement term: {cpm_update_direction}')
+
     return [
         pcs.ExternalPotentialPlugin(lambda_x=lambda_dir * cos(target_angle),
-                                    lambda_y=lambda_dir * sin(target_angle))
+                                    lambda_y=lambda_dir * sin(target_angle),
+                                    com_based=cpm_update_direction == 'cell-mass-displacement')
     ]
 
 
 def _impl_MODEL005(**kwargs):
+    cpm_force_mode = kwargs['cpm_force_mode']
+    cpm_update_direction = kwargs['cpm_update_direction']
+
+    if cpm_force_mode in ['extension', 'contraction']:
+        raise ValueError(f'CC3D does not support the specified force mode: {cpm_force_mode}')
+    if cpm_update_direction == 'source-to-target-norm':
+        raise ValueError(f'CC3D does not support the specified movement term: {cpm_update_direction}')
+
     return [
-        pcs.ExternalPotentialPlugin()
+        pcs.ExternalPotentialPlugin(com_based=cpm_update_direction == 'cell-mass-displacement')
     ]
 
 

--- a/implementations/compucell3d/model.py
+++ b/implementations/compucell3d/model.py
@@ -22,7 +22,7 @@ def _impl_MODEL003(**kwargs):
     cpm_force_mode = kwargs['cpm_force_mode']
     cpm_update_direction = kwargs['cpm_update_direction']
 
-    if cpm_force_mode in ['extension', 'contraction']:
+    if cpm_force_mode in ['extension', 'retraction']:
         raise ValueError(f'CC3D does not support the specified force mode: {cpm_force_mode}')
     if cpm_update_direction == 'source-to-target-norm':
         raise ValueError(f'CC3D does not support the specified movement term: {cpm_update_direction}')
@@ -38,7 +38,7 @@ def _impl_MODEL005(**kwargs):
     cpm_force_mode = kwargs['cpm_force_mode']
     cpm_update_direction = kwargs['cpm_update_direction']
 
-    if cpm_force_mode in ['extension', 'contraction']:
+    if cpm_force_mode in ['extension', 'retraction']:
         raise ValueError(f'CC3D does not support the specified force mode: {cpm_force_mode}')
     if cpm_update_direction == 'source-to-target-norm':
         raise ValueError(f'CC3D does not support the specified movement term: {cpm_update_direction}')

--- a/implementations/compucell3d/simulate.py
+++ b/implementations/compucell3d/simulate.py
@@ -3,6 +3,7 @@ from cc3d.core.PySteppables import SteppableBasePy
 import json
 from math import cos, pi, sin
 import multiprocessing as mp
+import numpy as np
 import os
 from random import random, seed
 from typing import Any, Dict, List, Optional, Tuple, Type
@@ -196,6 +197,46 @@ class Model005SteppableImplementation(ModelSteppableImplementation):
         cell.lambdaVecY -= self.persist * (cell.lambdaVecY + self.mu * disp[1])
 
         self.record_pos(_parent, mcs)
+
+
+@register_implementation
+class Model006SteppableImplementation(ModelSteppableImplementation):
+
+    def __init__(self, _parent: TrackingSteppable):
+
+        super().__init__(_parent)
+
+        seed()
+
+        self.ang_hist = 0
+
+        self.xi2 = _parent.model_args['xi'] ** 2
+        self.dt = _parent.model_args['dt']
+        self.sqrt_dt = np.sqrt(self.dt)
+        lambda_dir = _parent.model_args['lambda_dir']
+        self.ang = np.arctan2(lambda_dir[1], lambda_dir[0])
+        self.mu = np.sqrt(lambda_dir[0] ** 2 + lambda_dir[1] ** 2)
+
+    @classmethod
+    def model_name(cls) -> str:
+        return 'MODEL006'
+
+    def update_cell(self, _parent, _mcs):
+
+        cell = _parent.cell
+        cell.lambdaVecX = - self.mu * cos(self.ang)
+        cell.lambdaVecY = - self.mu * sin(self.ang)
+        self.ang_hist = _mcs
+
+    def start(self, _parent: TrackingSteppable):
+
+        self.update_cell(_parent, 0)
+
+    def step(self, _parent: TrackingSteppable, mcs):
+
+        if mcs - self.ang_hist >= self.dt:
+            self.ang += np.random.normal(scale=self.xi2) * self.sqrt_dt
+            self.update_cell(_parent, mcs)
 
 
 def create_sim(specs, cell_type_name: str, cell_length_target: int, init_domain: List[Tuple[int, int]], output_per: int, model_name: str, model_args: Dict[str, Any], *args, **kwargs):


### PR DESCRIPTION
Addresses https://github.com/tjsego/PersistentCell/issues/15. 

Experiments are here populated with features that CC3D can currently support, but they are not the same as what's described in [models.md](https://github.com/tjsego/PersistentCell/blob/start/schemas/models.md). I can add CC3D support for additional inputs but those additions would need to go through the development process before being available in a future release. So we need to decide details on experiments here before merging. 